### PR TITLE
Enforce inline action for issue & retire

### DIFF
--- a/eosio.wram.spec.ts
+++ b/eosio.wram.spec.ts
@@ -354,7 +354,10 @@ describe(wram_contract, () => {
     })
 
     test('issue::error - must be executed by contract', async () => {
-        const action = contracts.wram.actions.issue([wram_contract, `10000 ${RAM_SYMBOL}`, '']).send(wram_contract)
-        await expectToThrow(action, 'eosio_assert: must be executed by contract')
+        const action_issue = contracts.wram.actions.issue([wram_contract, `10000 ${RAM_SYMBOL}`, '']).send(wram_contract)
+        await expectToThrow(action_issue, 'eosio_assert: must be executed by contract')
+
+        const action_retire = contracts.wram.actions.retire([`10000 ${RAM_SYMBOL}`, '']).send(wram_contract)
+        await expectToThrow(action_retire, 'eosio_assert: must be executed by contract')
     })
 })

--- a/eosio.wram.spec.ts
+++ b/eosio.wram.spec.ts
@@ -352,4 +352,9 @@ describe(wram_contract, () => {
         const action = contracts.wram.actions.transfer([wram_contract, wram_contract, `0 ${RAM_SYMBOL}`, '']).send(wram_contract)
         await expectToThrow(action, 'eosio_assert: cannot transfer to self')
     })
+
+    test('issue::error - must be executed by contract', async () => {
+        const action = contracts.wram.actions.issue([wram_contract, `10000 ${RAM_SYMBOL}`, '']).send(wram_contract)
+        await expectToThrow(action, 'eosio_assert: must be executed by contract')
+    })
 })

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -41,6 +41,7 @@ void wram::issue( const name& to, const asset& quantity, const string& memo )
     check( to == st.issuer, "tokens can only be issued to issuer account" );
 
     require_auth( st.issuer );
+    check( get_sender() == get_self(), "must be executed by contract");
     check( quantity.is_valid(), "invalid quantity" );
     check( quantity.amount > 0, "must issue positive quantity" );
 
@@ -66,6 +67,7 @@ void wram::retire( const asset& quantity, const string& memo )
     const auto& st = *existing;
 
     require_auth( st.issuer );
+    check( get_sender() == get_self(), "must be executed by contract");
     check( quantity.is_valid(), "invalid quantity" );
     check( quantity.amount > 0, "must retire positive quantity" );
 


### PR DESCRIPTION
1. WRAM contract operates as intended
2. Fail transaction if `issue` or `retire` is triggered manually (even by eosio.wram itself)